### PR TITLE
Feature/combine boot2docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,23 +19,46 @@ vagrant ssh
 
 ```
 
-Your home folder is by default mounted in the same path as locally (e.g `/Users/hschaeidt`)
+### Linux / Unix
+Your home folder is by default mounted in the same path as locally (e.g `/Users/hschaeidt` | `/home/hschaeidt`)
+
+### Windows
+Your home folder is by default mounted in the following path: `/home/vagrant/c:/hschaeidt`
 
 ##Optional use together with boot2docker
-Add following to your Vagrantfile
+As speed matters, the boot2docker image support has been added to this image. This vagrant box can use the official boot2docker image remotely, means executing the commands like docker-compose on it.
 
+1. Start the boot2docker virtualbox file the official way
 ```
-home = ENV['HOME']
+# linux/unix
+$ boot2docker up
 
-Vagrant.configure(2) do |config|
-  config.vm.provision "shell", :args => '#{home}', inline: <<-SHELL
-    echo 'export DOCKER_HOST=tcp://192.168.59.103:2376' >> /home/vagrant/.bashrc
-    echo "export DOCKER_CERT_PATH=$1/.boot2docker/certs/boot2docker-vm"
-    echo 'export DOCKER_TLS_VERIFY=1'
-  SHELL
-end
-
+# windows in git-bash
+$ boot2docker.exec up
 ```
+
+2. Comment in the concerned section in the Vagrantfile
+3. Recreate this image by running `vagrant destroy -f && vagrant up`
+4. Use it the way described in the 'Usage' section above
+
+## Troubleshooting
+Problem: Docker daemon timeout
+Solution1: SSH into the boot2docker and check if the daemon is running / if not destroy and recreate the boot2docker image using boot2docker cli
+```
+# linux/unix
+$ boot2docker help
+
+# windows in git-bash
+$ boot2docker.exec help
+```
+
+Solution2: Check if the IP-Adress matches within your Vagrantfile and your boot2docker box
+```
+$ boot2docker ssh
+$ ip addr
+```
+
+Replace the IP-Adress if needed
 
 # Tweak it!
 Take out the maximum of the image by increasing the CPU & Memory.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,23 @@ vagrant ssh
 
 ```
 
-Your home folder is by default mounted in `/vagrant`
+Your home folder is by default mounted in the same path as locally (e.g `/Users/hschaeidt`)
+
+##Optional use together with boot2docker
+Add following to your Vagrantfile
+
+```
+home = ENV['HOME']
+
+Vagrant.configure(2) do |config|
+  config.vm.provision "shell", :args => '#{home}', inline: <<-SHELL
+    echo 'export DOCKER_HOST=tcp://192.168.59.103:2376' >> /home/vagrant/.bashrc
+    echo "export DOCKER_CERT_PATH=$1/.boot2docker/certs/boot2docker-vm"
+    echo 'export DOCKER_TLS_VERIFY=1'
+  SHELL
+end
+
+```
 
 # Tweak it!
 Take out the maximum of the image by increasing the CPU & Memory.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,13 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+host = RbConfig::CONFIG['host_os']
+if host =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+  home = "/home/vagrant/" + ENV['HOME']
+else
+  home = ENV['HOME']
+end
+
 Vagrant.configure(2) do |config|
   # The most common configuration options are documented and commented below.
   # For a complete reference, please see the online documentation at
@@ -20,7 +27,7 @@ Vagrant.configure(2) do |config|
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
-  config.vm.provision "shell", inline: <<-SHELL
+  config.vm.provision "shell", :args => "#{home}", inline: <<-SHELL
     # Installs latest docker client
     # https://docs.docker.com/installation/ubuntulinux/
     wget -qO- https://get.docker.com/ | sh
@@ -33,5 +40,11 @@ Vagrant.configure(2) do |config|
     # https://docs.docker.com/compose/install/
     curl -L https://github.com/docker/compose/releases/download/1.1.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
     chmod +x /usr/local/bin/docker-compose
+
+    # Comment in the following 3 line to enable remote access to the official boot2docker image (much performant wow)
+    # Chekout the README.md if you are not sure how to use this
+    # echo 'export DOCKER_HOST=tcp://192.168.59.103:2376' >> /home/vagrant/.bashrc
+    # echo "export DOCKER_CERT_PATH=$1/.boot2docker/certs/boot2docker-vm" >>/home/vagrant/.bashrc
+    # echo 'export DOCKER_TLS_VERIFY=1' >> /home/vagrant/.bashrc
   SHELL
 end


### PR DESCRIPTION
This PR adds support to a remote official boot2docker image in combination with this machine.
This box will only act as remote executor. It is actually a workaround to use other docker tools not officially supported by the boot2docker box (e.g. docker-compose) under windows.
